### PR TITLE
最低限の検索結果画面を実装

### DIFF
--- a/app/views/searchs/search.html.erb
+++ b/app/views/searchs/search.html.erb
@@ -1,3 +1,12 @@
-<% @datas.each do |commentator| %>
-  <%= commentator.name %>
+<p>オススメ実況者は...</p>
+
+<% if @datas.blank? %>
+	<p>見つかりませんでした。</p>
+<% else %>
+	<% @datas.each do |commentator| %>
+    <%= commentator.name %>
+  <% end %>
 <% end %>
+
+<%= link_to 'タイトルに戻る', root_path %>
+


### PR DESCRIPTION
オススメ実況者が1人もいない場合と1人以上いる場合で、結果画面のビューを切り替えた